### PR TITLE
Final tweaks to package

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,4 @@
-^miniSPARRA01\.Rproj$
+^eider\.Rproj$
 ^\.Rproj\.user$
 ^_pkgdown\.yml$
 ^docs$
@@ -7,6 +7,7 @@
 ^doc$
 ^Meta$
 ^README\.Rmd$
+^README\.md$
 ^.github$
 ^.pre-commit-config\.yaml$
 ^.lintr$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: eider
-Title: Declarative feature extraction from tabular records data
+Title: Declarative Feature Extraction From Tabular Records Data
 Version: 0.0.1.0
 Authors@R: c(
     person("Catalina", "Vallejos", email = "catalina.vallejos@ed.ac.uk", role = c("ctb"), comment = c(ORCID = "0000-0003-3638-1960")),

--- a/README.Rmd
+++ b/README.Rmd
@@ -47,7 +47,7 @@ You can install `eider` from [GitHub](https://github.com/) using:
 
 ``` r
 install.packages("devtools")
-devtools::install_github("alan-turing-institute/eider")
+devtools::install_github("alan-turing-institute/eider", build_vignettes = TRUE)
 ```
 
 We plan to submit `eider` to CRAN in the near future.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can install `eider` from [GitHub](https://github.com/) using:
 
 ``` r
 install.packages("devtools")
-devtools::install_github("alan-turing-institute/eider")
+devtools::install_github("alan-turing-institute/eider", build_vignettes = TRUE)
 ```
 
 We plan to submit `eider` to CRAN in the near future.

--- a/vignettes/features.Rmd
+++ b/vignettes/features.Rmd
@@ -134,7 +134,7 @@ Examples of `"time_since"` features are given in [A&E feature 4](examples_ae.htm
 Combination features are a way of combining the results of multiple features into a single feature.
 They have a slightly different structure to the rest: broadly speaking, these transformation types require a `subfeature` key, which is itself an object which contains the features which are to be combined.
 
-Combination features are covered in a [separate vignette](feature_combine.html).
+Combination features are covered in a [separate vignette](combination.html).
 
 
 ## Preprocessing and filtering


### PR DESCRIPTION
When reviewing the latest version I spotted some *very* minor things which I've fixed here:

- [x] As discussed on the call just now, I'd suggest having `build_vignettes = TRUE` in the recommended install command, otherwise much of the super helpful documentation will not be available locally on user's machines.
- [x] `.Rbuildignore` is out of date and referenced the old package name.
- [x] For some reason the turing.ac.uk domain is triggering errors on automated checks, so I'd suggest adding `README.md` to the build ignore list too.
- [x] In the penultimate section of the "Overview of features" vignette, the link to "separate vignette" is broken.
- [x] The description file title must be in title case for CRAN submission.

Hope these fixes look ok!
